### PR TITLE
Run subscription SQL

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -206,7 +206,15 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      handle_subscription_after_payment: {
+        Args: {
+          p_user_id: string
+          p_username: string
+          p_email: string
+          p_subscription_tier: string
+        }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/functions/complete-payment/index.ts
+++ b/supabase/functions/complete-payment/index.ts
@@ -128,6 +128,33 @@ Deno.serve(async (req) => {
         updated_at: new Date().toISOString()
       }).eq('payment_id', paymentRequest.paymentId);
 
+      // Handle subscription creation if payment is completed successfully
+      if (paymentRequest.metadata?.subscriptionTier) {
+        try {
+          // Get user data from metadata or create defaults
+          const username = paymentRequest.metadata.username || `user_${paymentRequest.userId.slice(0, 8)}`;
+          const email = paymentRequest.metadata.email || `${username}@pi.app`;
+          
+          // Call the database function to handle subscription
+          const { error: subscriptionError } = await supabaseClient.rpc('handle_subscription_after_payment', {
+            p_user_id: paymentRequest.userId,
+            p_username: username,
+            p_email: email,
+            p_subscription_tier: paymentRequest.metadata.subscriptionTier
+          });
+
+          if (subscriptionError) {
+            console.error('Failed to create subscription:', subscriptionError);
+            // Don't fail the entire request since payment was successful
+          } else {
+            console.log(`Subscription ${paymentRequest.metadata.subscriptionTier} created for user ${paymentRequest.userId}`);
+          }
+        } catch (subscriptionErr) {
+          console.error('Error handling subscription:', subscriptionErr);
+          // Don't fail the entire request since payment was successful
+        }
+      }
+
       const endTime = Date.now();
       console.log(`Payment completion successful in ${endTime - startTime}ms`);
 
@@ -136,7 +163,8 @@ Deno.serve(async (req) => {
           success: true, 
           message: 'Payment completed successfully', 
           paymentId: paymentRequest.paymentId,
-          txid: paymentRequest.txid 
+          txid: paymentRequest.txid,
+          subscriptionCreated: !!paymentRequest.metadata?.subscriptionTier
         }),
         { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );

--- a/supabase/migrations/20250801013025_6f1ed8da-7845-4003-a285-f1d73fc814cb.sql
+++ b/supabase/migrations/20250801013025_6f1ed8da-7845-4003-a285-f1d73fc814cb.sql
@@ -1,0 +1,83 @@
+-- Enable RLS on users table
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+
+-- Create policy for users to view their own data
+CREATE POLICY "Users can view their own data" 
+ON public.users 
+FOR SELECT 
+USING (auth.uid() = id);
+
+-- Create policy for users to update their own data
+CREATE POLICY "Users can update their own data" 
+ON public.users 
+FOR UPDATE 
+USING (auth.uid() = id);
+
+-- Create policy for users to insert their own data
+CREATE POLICY "Users can insert their own data" 
+ON public.users 
+FOR INSERT 
+WITH CHECK (auth.uid() = id);
+
+-- Enable RLS on subscriptions table
+ALTER TABLE public.subscriptions ENABLE ROW LEVEL SECURITY;
+
+-- Create policy for users to view their own subscriptions
+CREATE POLICY "Users can view their own subscriptions" 
+ON public.subscriptions 
+FOR SELECT 
+USING (auth.uid() = user_id);
+
+-- Create policy for users to insert their own subscriptions
+CREATE POLICY "Users can insert their own subscriptions" 
+ON public.subscriptions 
+FOR INSERT 
+WITH CHECK (auth.uid() = user_id);
+
+-- Create policy for users to update their own subscriptions
+CREATE POLICY "Users can update their own subscriptions" 
+ON public.subscriptions 
+FOR UPDATE 
+USING (auth.uid() = user_id);
+
+-- Function to handle subscription creation/update after payment completion
+CREATE OR REPLACE FUNCTION handle_subscription_after_payment(
+  p_user_id uuid,
+  p_username text,
+  p_email text,
+  p_subscription_tier text
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_subscription_start timestamp;
+  v_subscription_end timestamp;
+BEGIN
+  -- Set subscription dates (1 month duration)
+  v_subscription_start := now();
+  v_subscription_end := now() + interval '1 month';
+  
+  -- Insert or update user record
+  INSERT INTO public.users (id, username, email, subscription, created_at)
+  VALUES (p_user_id, p_username, p_email, p_subscription_tier, now())
+  ON CONFLICT (id) 
+  DO UPDATE SET 
+    subscription = p_subscription_tier,
+    username = COALESCE(EXCLUDED.username, users.username),
+    email = COALESCE(EXCLUDED.email, users.email);
+  
+  -- End any existing active subscriptions for this user
+  UPDATE public.subscriptions 
+  SET end_date = now() 
+  WHERE user_id = p_user_id 
+    AND end_date > now();
+  
+  -- Create new subscription record
+  INSERT INTO public.subscriptions (user_id, plan, start_date, end_date)
+  VALUES (p_user_id, p_subscription_tier, v_subscription_start, v_subscription_end);
+  
+  RAISE LOG 'Subscription created for user % with plan % from % to %', 
+    p_user_id, p_subscription_tier, v_subscription_start, v_subscription_end;
+END;
+$$;


### PR DESCRIPTION
Ran SQL to create `handle_subscription_after_payment` function and associated RLS policies for `users` and `subscriptions` tables. This ensures user subscriptions are recorded with a one-month duration and properly managed after payment.