### PR TITLE
Fix false-success toast when re-auth fails during Message tap

### DIFF
--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -4,6 +4,7 @@ import { useAuth } from '@/context/auth';
 import { toast } from 'sonner';
 import {
   enqueuePendingConversation,
+  resolvePendingConversation,
   setConversationRunner,
 } from '@/lib/pendingConversationQueue';
 import { useVerifiedSender } from '@/hooks/useVerifiedSender';
@@ -246,8 +247,27 @@ export function useMessages(inbox: Inbox | null) {
           // picks it up the moment SIGNED_IN / TOKEN_REFRESHED fires.
           const pending = enqueuePendingConversation(businessId);
           login()
-            .then(() => {
-              toast.success('Signed back in — resuming…', { id: toastId, duration: 4000 });
+            .then(async () => {
+              // login() resolves even when auth genuinely failed (it handles
+              // its own errors internally), so confirm a real session exists
+              // before declaring success.
+              const { data: postLogin } = await supabase.auth.getSession();
+              if (postLogin?.session?.user?.id) {
+                toast.success('Signed back in — resuming…', { id: toastId, duration: 4000 });
+                return;
+              }
+              console.error(
+                '[startConversationWithBusiness] re-auth completed without a session',
+                { ...ctxBase, reason },
+              );
+              recordReauthEvent('reauth_failed', {
+                ...telemetryCtx,
+                message: 'login() resolved but no session was established',
+              });
+              toast.error('Sign-in failed. Please try again.', { id: toastId, duration: 4000 });
+              // Resolve the queued request now so the caller gets a prompt
+              // failure instead of hanging until the in-flight timeout.
+              resolvePendingConversation(businessId, null);
             })
             .catch((err) => {
               console.error('[startConversationWithBusiness] re-auth failed', {
@@ -261,6 +281,7 @@ export function useMessages(inbox: Inbox | null) {
                 err,
               );
               toast.error('Sign-in failed. Please try again.', { id: toastId, duration: 4000 });
+              resolvePendingConversation(businessId, null);
             });
           return pending;
         };

--- a/src/lib/pendingConversationQueue.ts
+++ b/src/lib/pendingConversationQueue.ts
@@ -63,6 +63,23 @@ export const drainPendingConversations = async (): Promise<void> => {
 };
 
 /**
+ * Resolve queued request(s) for a specific business immediately — used when
+ * re-auth finished without producing a session, so the caller gets a prompt
+ * failure instead of waiting for the drain or in-flight timeout.
+ */
+export const resolvePendingConversation = (
+  businessId: number,
+  result: string | null,
+): void => {
+  for (let i = pending.length - 1; i >= 0; i--) {
+    if (pending[i].businessId === businessId) {
+      const [item] = pending.splice(i, 1);
+      item.resolve(result);
+    }
+  }
+};
+
+/**
  * Reject all pending items — used when the user signs out before re-auth
  * completes, so callers don't hang forever.
  */

--- a/tests/e2e/reauth-false-success.spec.ts
+++ b/tests/e2e/reauth-false-success.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression test for the re-auth false-success gap in reAuthAndRetry()
+ * (src/hooks/useMessages.ts).
+ *
+ * Scenario: the user has a cached local PiUser but NO Supabase session.
+ * Tapping "Message" on a business card triggers reAuthAndRetry
+ * ('missing-session') → login(). login() always resolves — even when
+ * authentication genuinely fails — so the old code fired a false
+ * "Signed back in — resuming…" success toast and the queued conversation
+ * request hung until the 15s in-flight timeout produced "Couldn't open
+ * the conversation."
+ *
+ * The fix re-checks supabase.auth.getSession() after login() resolves;
+ * with no session it shows an honest "Sign-in failed" toast and resolves
+ * the queued request promptly via resolvePendingConversation().
+ *
+ * The genuinely-failing login is simulated without live Pi auth: the real
+ * SDK script is blocked and window.Pi is stubbed with an authenticate()
+ * that rejects immediately (isPiBrowser() treats a present window.Pi as
+ * Pi Browser, so performLogin() proceeds and fails fast through its retry
+ * loop). The sandbox mock session (honored on localhost / Lovable preview
+ * hosts only) provides the "local user without a Supabase session"
+ * starting state.
+ */
+import { test, expect } from '@playwright/test';
+
+const SANDBOX_MOCK_KEY = 'avante_sandbox_mock_session';
+const STORAGE_KEY = 'avante_maps_auth';
+
+// Mirrors the loginAsSandbox() fallback user in AuthProvider.tsx.
+const mockUser = {
+  uid: '00000000-0000-0000-0000-000000000001',
+  pi_uid: 'sandbox-mock-pi-uid',
+  username: 'SandboxUser',
+  walletAddress: 'sandbox-mock-wallet',
+  roles: ['user'],
+  accessToken: 'sandbox-mock-token',
+  subscriptionTier: 'organization',
+  businessCount: 0,
+};
+
+test('failed re-auth on Message tap shows honest failure, not false success', async ({ page }) => {
+  // Block the real Pi SDK so it can't overwrite the stub below.
+  await page.route('**/pi-sdk.js', (route) => route.abort());
+
+  await page.addInitScript(
+    ([mockKey, storageKey, user]) => {
+      localStorage.setItem(mockKey as string, '1');
+      localStorage.setItem(
+        storageKey as string,
+        JSON.stringify({ ...(user as object), lastAuthenticated: Date.now() }),
+      );
+      // Stub Pi SDK: present (so the login flow proceeds) but authentication
+      // always fails fast — the "genuine auth failure" this test exercises.
+      (window as unknown as { Pi: object }).Pi = {
+        init: () => undefined,
+        authenticate: () => Promise.reject(new Error('User cancelled the authentication request')),
+      };
+      (window as unknown as { __piInitialized: boolean }).__piInitialized = true;
+    },
+    [SANDBOX_MOCK_KEY, STORAGE_KEY, mockUser],
+  );
+
+  await page.goto('/');
+
+  // Business markers come from live Supabase data (public RPC); skip rather
+  // than fail if none are available to click.
+  const marker = page.locator('.leaflet-marker-icon').first();
+  try {
+    await marker.waitFor({ state: 'visible', timeout: 20_000 });
+  } catch {
+    test.skip(true, 'No business markers available on the map');
+  }
+  await marker.click({ force: true });
+
+  const messageButton = page.getByRole('button', { name: 'Message' }).first();
+  await messageButton.waitFor({ state: 'visible', timeout: 15_000 });
+  await messageButton.click();
+
+  // Sanity anchor: we must have entered the re-auth path (cached user with
+  // no Supabase session), not the plain "Sign in to message businesses"
+  // signed-out branch.
+  await expect(page.getByText('Signing you back in…')).toBeVisible({ timeout: 10_000 });
+
+  // login() resolves without a session (stubbed authenticate rejects, and
+  // performLogin's ~3 fast retry attempts exhaust). The fix must surface an
+  // honest failure toast promptly — well inside the old 15s stall window.
+  await expect(page.getByText('Sign-in failed. Please try again.')).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // resolvePendingConversation(null) must fail the queued request promptly,
+  // giving the card's honest error instead of a hang until the 15s timeout.
+  await expect(
+    page.getByText("Couldn't open the conversation. Please try again."),
+  ).toBeVisible({ timeout: 5_000 });
+
+  // The false-positive toast this regression test exists for must never fire.
+  await expect(page.getByText('Signed back in — resuming…')).toHaveCount(0);
+});


### PR DESCRIPTION
## What

Second gap in the CommuniCon messaging bug chain (independent of the Bug #4 network-fallback fix already on Dev): `login()` in `AuthProvider.tsx` always resolves — even on genuine auth failure — so `reAuthAndRetry()` in `useMessages.ts` fired a false **"Signed back in — resuming…"** success toast, and the queued conversation request sat in `pendingConversationQueue` until the 15s in-flight timeout resolved it to `null`, reproducing "Couldn't open the conversation. Please try again."

## Changes (scoped to exactly two source files, per plan)

- **`src/lib/pendingConversationQueue.ts`** — new `resolvePendingConversation(businessId, result)` export: resolves matching queued item(s) immediately instead of waiting for a drain event or TTL.
- **`src/hooks/useMessages.ts`** — after `login()` resolves, `reAuthAndRetry()` now re-checks `supabase.auth.getSession()`. With a real session: unchanged success toast. Without one: honest "Sign-in failed. Please try again." toast + prompt `resolvePendingConversation(businessId, null)` so the caller fails fast instead of stalling 15s. The (currently unreachable) `.catch()` is kept as a fallback and also resolves the queued item now.
- **`tests/e2e/reauth-false-success.spec.ts`** — Playwright regression test: sandbox mock user (local user, no Supabase session) + stubbed `window.Pi.authenticate` that rejects, real SDK script blocked. Verified to fail against the unfixed code and pass with the fix.

`AuthProvider.tsx`'s `login()` contract is deliberately untouched (~10 fire-and-forget call sites).

## Verification

- `tsc --noEmit` clean on all three tsconfigs; ESLint on touched files shows only the 8 pre-existing findings identical to the Dev baseline (verified via stash-compare) — no new `any`, no new warnings.
- Regression test run both ways: fails on old code (14.5s, false success fires), passes on fixed code (5s).
- Traced both flows: re-auth succeeds → session exists → unchanged success toast, dispatcher drains queue on SIGNED_IN; re-auth fails → honest failure toast + prompt queue resolution → card shows its error immediately instead of after 15s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)